### PR TITLE
Refactor build scripts and CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,26 +1,59 @@
 name: 'build'
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
-  build:
+  IDFboot:
     runs-on: ubuntu-20.04
-    steps: 
-      - uses: actions/checkout@v1
+    strategy:
+      matrix:
+        targets: [esp32, esp32s2, esp32c3]
+    steps:
+      - uses: actions/checkout@v2
       - name: Build IDF bootloader and partition table
         uses: docker://docker.io/espressif/idf:release-v4.3
         with:
-          args: ./build_idfboot.sh
+          args: ./build_idfboot.sh -c ${{matrix.targets}}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: idf-builds
+          path: out/
+
+  MCUboot:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        targets: [esp32]
+    steps:
+      - uses: actions/checkout@v2
       - name: Build MCUboot bootloader
         uses: docker://docker.io/espressif/idf:release-v4.3
         with:
-          args: ./build_mcuboot.sh
+          args: ./build_mcuboot.sh -s -c ${{matrix.targets}}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: mcuboot-builds
+          path: out/
+
+  Release-Artifacts:
+    runs-on: ubuntu-20.04
+    needs: [IDFboot, MCUboot]
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: buildartifacts/
       - name: Update release
         if: "github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')"
         uses: eine/tip@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |
-            out/*
+            buildartifacts/idf-builds/*
+            buildartifacts/mcuboot-builds/*
           tag: latest
           rm: true

--- a/README.md
+++ b/README.md
@@ -38,14 +38,21 @@ Scratch slot size | 0x40000 (256 KiB)
 
 # Building locally
 
+Clone this repository and change to the newly created directory:
+
+```bash
+git clone https://github.com/espressif/esp-nuttx-bootloader.git
+cd esp-nuttx-bootloader
+```
+
+Next, follow the instructions according to the bootloader choice.
+
 ## IDF bootloader
 
 It is recommended to build the binaries inside the `espressif/idf` Docker image.
 
 ```bash
-git clone https://github.com/espressif/esp-nuttx-bootloader.git
-cd esp-nuttx-bootloader
-docker run --rm -v $PWD:/work -w /work espressif/idf:release-v4.3 ./build_idfboot.sh
+docker run --rm -v $PWD:/work -w /work espressif/idf:release-v4.3 ./build_idfboot.sh -c <chip>
 ```
 
 The binaries will be inside `out` directory.
@@ -63,12 +70,18 @@ For more information about these files, refer to the following chapters of IDF P
 
 ## MCUboot bootloader
 
+First of all, make sure the MCUboot repository and its dependencies are up-to-date:
+
+```bash
+git submodule update --init mcuboot
+cd mcuboot
+git submodule update --init --recursive ext/mbedtls
+```
+
 It is recommended to build the binaries inside the `espressif/idf` Docker image.
 
 ```bash
-git clone https://github.com/espressif/esp-nuttx-bootloader.git
-cd esp-nuttx-bootloader
-docker run --rm -v $PWD:/work -w /work espressif/idf:release-v4.3 ./build_mcuboot.sh
+docker run --rm -v $PWD:/work -w /work espressif/idf:release-v4.3 ./build_mcuboot.sh -c <chip>
 ```
 
 The binaries will be inside `out` directory.

--- a/build_idfboot.sh
+++ b/build_idfboot.sh
@@ -1,15 +1,79 @@
 #!/usr/bin/env bash
+#
+#  Copyright (c) 2021 Espressif Systems (Shanghai) Co., Ltd.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 
-set -euo pipefail
+SCRIPT_ROOTDIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
+SCRIPT_NAME=$(basename "${BASH_SOURCE[0]}")
 
-targets="esp32 esp32s2 esp32c3"
+set -eo pipefail
 
-mkdir -p out
+supported_targets=("esp32" "esp32s2" "esp32c3")
 
-for target in ${targets}; do
-    idf.py set-target ${target}
-    idf.py bootloader partition_table
-    cp build/bootloader/bootloader.bin out/bootloader-${target}.bin
-    cp build/partition_table/partition-table.bin out/partition-table-${target}.bin
-    cp sdkconfig out/sdkconfig-${target}
+usage() {
+    echo ""
+    echo "USAGE: ${SCRIPT_NAME} [-h] -c <chip>"
+    echo ""
+    echo "Where:"
+    echo "  -c <chip> Target chip (options: ${supported_targets[*]})"
+    echo "  -h Show usage and terminate"
+    echo ""
+}
+
+build_idfboot() {
+    local target=${1}
+    local build_dir=".build-${target}"
+    local output_dir="${SCRIPT_ROOTDIR}/out"
+
+    pushd "${SCRIPT_ROOTDIR}" &>/dev/null
+    mkdir -p "${output_dir}" &>/dev/null
+
+    # Build bootloader for selected target
+
+    idf.py -B "${build_dir}" set-target "${target}"
+    idf.py -B "${build_dir}" bootloader partition_table
+
+    # Copy bootloader binary file to output directory
+
+    cp "${build_dir}"/bootloader/bootloader.bin "${output_dir}"/bootloader-"${target}".bin
+    cp "${build_dir}"/partition_table/partition-table.bin "${output_dir}"/partition-table-"${target}".bin
+    mv sdkconfig "${output_dir}"/sdkconfig-"${target}"
+
+    # Remove build directory
+
+    rm -rf "${build_dir}" &>/dev/null
+
+    popd &>/dev/null
+}
+
+while getopts ":hc:" arg; do
+  case "${arg}" in
+    c)
+      chip=${OPTARG}
+      ;;
+    h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
 done
+
+if [ -z "${chip}" ]; then
+    printf "ERROR: Missing target chip.\n"
+    usage
+    exit 1
+fi
+
+if [[ ! "${supported_targets[*]}" =~ "${chip}" ]]; then
+    printf "ERROR: Target \"%s\" is not supported!\n" "${chip}"
+    usage
+    exit 1
+fi
+
+build_idfboot "${chip}"

--- a/build_idfboot.sh
+++ b/build_idfboot.sh
@@ -13,39 +13,39 @@ set -eo pipefail
 supported_targets=("esp32" "esp32s2" "esp32c3")
 
 usage() {
-    echo ""
-    echo "USAGE: ${SCRIPT_NAME} [-h] -c <chip>"
-    echo ""
-    echo "Where:"
-    echo "  -c <chip> Target chip (options: ${supported_targets[*]})"
-    echo "  -h Show usage and terminate"
-    echo ""
+  echo ""
+  echo "USAGE: ${SCRIPT_NAME} [-h] -c <chip>"
+  echo ""
+  echo "Where:"
+  echo "  -c <chip> Target chip (options: ${supported_targets[*]})"
+  echo "  -h Show usage and terminate"
+  echo ""
 }
 
 build_idfboot() {
-    local target=${1}
-    local build_dir=".build-${target}"
-    local output_dir="${SCRIPT_ROOTDIR}/out"
+  local target=${1}
+  local build_dir=".build-${target}"
+  local output_dir="${SCRIPT_ROOTDIR}/out"
 
-    pushd "${SCRIPT_ROOTDIR}" &>/dev/null
-    mkdir -p "${output_dir}" &>/dev/null
+  pushd "${SCRIPT_ROOTDIR}" &>/dev/null
+  mkdir -p "${output_dir}" &>/dev/null
 
-    # Build bootloader for selected target
+  # Build bootloader for selected target
 
-    idf.py -B "${build_dir}" set-target "${target}"
-    idf.py -B "${build_dir}" bootloader partition_table
+  idf.py -B "${build_dir}" set-target "${target}"
+  idf.py -B "${build_dir}" bootloader partition_table
 
-    # Copy bootloader binary file to output directory
+  # Copy bootloader binary file to output directory
 
-    cp "${build_dir}"/bootloader/bootloader.bin "${output_dir}"/bootloader-"${target}".bin
-    cp "${build_dir}"/partition_table/partition-table.bin "${output_dir}"/partition-table-"${target}".bin
-    mv sdkconfig "${output_dir}"/sdkconfig-"${target}"
+  cp "${build_dir}"/bootloader/bootloader.bin "${output_dir}"/bootloader-"${target}".bin
+  cp "${build_dir}"/partition_table/partition-table.bin "${output_dir}"/partition-table-"${target}".bin
+  mv sdkconfig "${output_dir}"/sdkconfig-"${target}"
 
-    # Remove build directory
+  # Remove build directory
 
-    rm -rf "${build_dir}" &>/dev/null
+  rm -rf "${build_dir}" &>/dev/null
 
-    popd &>/dev/null
+  popd &>/dev/null
 }
 
 while getopts ":hc:" arg; do
@@ -65,15 +65,15 @@ while getopts ":hc:" arg; do
 done
 
 if [ -z "${chip}" ]; then
-    printf "ERROR: Missing target chip.\n"
-    usage
-    exit 1
+  printf "ERROR: Missing target chip.\n"
+  usage
+  exit 1
 fi
 
 if [[ ! "${supported_targets[*]}" =~ "${chip}" ]]; then
-    printf "ERROR: Target \"%s\" is not supported!\n" "${chip}"
-    usage
-    exit 1
+  printf "ERROR: Target \"%s\" is not supported!\n" "${chip}"
+  usage
+  exit 1
 fi
 
 build_idfboot "${chip}"

--- a/build_mcuboot.sh
+++ b/build_mcuboot.sh
@@ -50,10 +50,18 @@ build_mcuboot() {
   local output_dir="${SCRIPT_ROOTDIR}/out"
   local toolchain_file="tools/toolchain-${target}.cmake"
   local mcuboot_config
+  local make_generator
+
   mcuboot_config=$(realpath "${config:-${SCRIPT_ROOTDIR}/mcuboot.conf}")
 
   pushd "${SCRIPT_ROOTDIR}" &>/dev/null
   mkdir -p "${output_dir}" &>/dev/null
+
+  # Build with Ninja if installed
+
+  if command -v ninja &>/dev/null; then
+    make_generator="-GNinja"
+  fi
 
   # Build bootloader for selected target
 
@@ -63,7 +71,7 @@ build_mcuboot() {
         -DMCUBOOT_CONFIG_FILE="${mcuboot_config}"   \
         -DIDF_PATH="${IDF_PATH}"                    \
         -B "${build_dir}"                           \
-        -GNinja                                     \
+        "${make_generator}"                         \
         "${source_dir}"
   cmake --build "${build_dir}"/
   esptool.py --chip "${target}" elf2image --flash_mode dio --flash_freq 40m \


### PR DESCRIPTION
This PR intends to enable the build scripts for both IDFboot and MCUboot to accept the target chip as input parameter.
There are two motivations for this refactor:
1) Breakdown the builds into several jobs for each Bootloader and Chip combination.
2) Enable the build scripts to be integrated into the NuttX build depending on user selection.

## Relevant changes
### Ease the usage of `build_mcuboot.sh` for building MCUboot outside of Docker
- Checkout the `esp-idf` submodule from MCUboot repository in case `IDF_PATH` is not set.
- If `IDF_PATH` is set, the script will build the source files this repository as long as it is checked out on the required IDF version.
- Use Ninja as the CMake makefile generator only if available. Otherwise, rely on the default Unix Makefiles.

### Parallelization of CI jobs per chip and bootloader implementation
- Both `build_idfboot.sh` and `build_mcuboot.sh` scripts now accept a `-c <chip>` option.

### Allow providing custom attributes for MCUboot application slots
- MCUboot configuration file may provided via `-f <file>` option.