### PR TITLE
README.md: Fix Docker instructions without local user info

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Next, follow the instructions according to the bootloader choice.
 It is recommended to build the binaries inside the `espressif/idf` Docker image.
 
 ```bash
-docker run --rm -v $PWD:/work -w /work espressif/idf:release-v4.3 ./build_idfboot.sh -c <chip>
+docker run --rm --user $(id -u):$(id -g) -v $PWD:/work -w /work espressif/idf:release-v4.3 ./build_idfboot.sh -c <chip>
 ```
 
 The binaries will be inside `out` directory.
@@ -81,7 +81,7 @@ git submodule update --init --recursive ext/mbedtls
 It is recommended to build the binaries inside the `espressif/idf` Docker image.
 
 ```bash
-docker run --rm -v $PWD:/work -w /work espressif/idf:release-v4.3 ./build_mcuboot.sh -c <chip>
+docker run --rm --user $(id -u):$(id -g) -v $PWD:/work -w /work espressif/idf:release-v4.3 ./build_mcuboot.sh -c <chip>
 ```
 
 The binaries will be inside `out` directory.


### PR DESCRIPTION
This PR intends to fix the instructions for building the bootloaders locally using Docker.

If the user information (ID and Group) is not provided to Docker, the local user will not have the appropriate access permissions to the build artifacts.