### PR TITLE
[IDFboot] Enable building esp-idf outside Docker

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "mcuboot"]
 	path = mcuboot
 	url = https://github.com/mcu-tools/mcuboot.git
+[submodule "esp-idf"]
+	path = esp-idf
+	url = https://github.com/espressif/esp-idf.git
+	branch = release/v4.3

--- a/build_idfboot.sh
+++ b/build_idfboot.sh
@@ -7,6 +7,7 @@
 
 SCRIPT_ROOTDIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
 SCRIPT_NAME=$(basename "${BASH_SOURCE[0]}")
+IDF_PATH="${IDF_PATH:-${SCRIPT_ROOTDIR}/esp-idf}"
 
 set -eo pipefail
 
@@ -18,28 +19,66 @@ usage() {
   echo ""
   echo "Where:"
   echo "  -c <chip> Target chip (options: ${supported_targets[*]})"
+  echo "  -f <file> Path to file containing bootloader configuration options"
+  echo "  -p <file> Path to file containing partition table information"
+  echo "  -s Setup environment"
   echo "  -h Show usage and terminate"
   echo ""
 }
 
+setup() {
+  if [ "${IDF_PATH}" == "${SCRIPT_ROOTDIR}/esp-idf" ]; then
+    git -C "${SCRIPT_ROOTDIR}" submodule update --init esp-idf
+  fi
+}
+
 build_idfboot() {
   local target=${1}
+  local config=${2}
+  local partinfo=${3}
   local build_dir=".build-${target}"
+  local source_dir="${IDF_PATH}/components/bootloader/subproject"
   local output_dir="${SCRIPT_ROOTDIR}/out"
+  local toolchain_file="${IDF_PATH}/tools/cmake/toolchain-${target}.cmake"
+  local idfboot_config
+  local idfboot_partinfo
+  local make_generator
+
+  idfboot_config=$(realpath "${config:-${SCRIPT_ROOTDIR}/sdkconfig.defaults}")
+  idfboot_partinfo=$(realpath "${partinfo:-${SCRIPT_ROOTDIR}/partitions.csv}")
 
   pushd "${SCRIPT_ROOTDIR}" &>/dev/null
   mkdir -p "${output_dir}" &>/dev/null
 
+  # Build with Ninja if installed
+
+  if command -v ninja &>/dev/null; then
+    make_generator="-GNinja"
+  fi
+
   # Build bootloader for selected target
 
-  idf.py -B "${build_dir}" set-target "${target}"
-  idf.py -B "${build_dir}" bootloader partition_table
+  export IDF_PATH=${IDF_PATH}
+  cmake -DCMAKE_TOOLCHAIN_FILE="${toolchain_file}"      \
+        -DSDKCONFIG_DEFAULTS="${idfboot_config}"        \
+        -DSDKCONFIG="${output_dir}/sdkconfig-${target}" \
+        -DIDF_PATH="${IDF_PATH}"                        \
+        -DIDF_TARGET="${target}"                        \
+        -DPYTHON_DEPS_CHECKED=1                         \
+        -B "${build_dir}"                               \
+        "${make_generator}"                             \
+        "${source_dir}"
+  cmake --build "${build_dir}"/
 
   # Copy bootloader binary file to output directory
 
-  cp "${build_dir}"/bootloader/bootloader.bin "${output_dir}"/bootloader-"${target}".bin
-  cp "${build_dir}"/partition_table/partition-table.bin "${output_dir}"/partition-table-"${target}".bin
-  mv sdkconfig "${output_dir}"/sdkconfig-"${target}"
+  cp "${build_dir}"/bootloader.bin "${output_dir}"/bootloader-"${target}".bin
+
+  # Generate partition table binary file
+
+  python "${IDF_PATH}"/components/partition_table/gen_esp32part.py \
+         "${idfboot_partinfo}"                                     \
+         "${output_dir}"/partition-table-"${target}".bin
 
   # Remove build directory
 
@@ -48,10 +87,19 @@ build_idfboot() {
   popd &>/dev/null
 }
 
-while getopts ":hc:" arg; do
+while getopts ":hc:f:p:s" arg; do
   case "${arg}" in
     c)
       chip=${OPTARG}
+      ;;
+    f)
+      config=${OPTARG}
+      ;;
+    p)
+      partinfo=${OPTARG}
+      ;;
+    s)
+      setup
       ;;
     h)
       usage
@@ -70,10 +118,22 @@ if [ -z "${chip}" ]; then
   exit 1
 fi
 
+if [ -n "${config}" ] && [ ! -f "${config}" ]; then
+  printf "ERROR: Bootloader configuration file %s not found.\n" "${config}"
+  usage
+  exit 1
+fi
+
+if [ -n "${partinfo}" ] && [ ! -f "${partinfo}" ]; then
+  printf "ERROR: Partition table file %s not found.\n" "${partinfo}"
+  usage
+  exit 1
+fi
+
 if [[ ! "${supported_targets[*]}" =~ "${chip}" ]]; then
   printf "ERROR: Target \"%s\" is not supported!\n" "${chip}"
   usage
   exit 1
 fi
 
-build_idfboot "${chip}"
+build_idfboot "${chip}" "${config}" "${partinfo}"

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -1,6 +1,3 @@
 # Use the partition table from this repository
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"
-
-# NuttX doesn't disable the RTC watchdog on startup, so don't enable it
-CONFIG_BOOTLOADER_WDT_ENABLE=n


### PR DESCRIPTION
This PR intends to refactor the IDFboot build script for easing the build outside of `espressif/esp-idf` Docker environment.

## Relevant changes
### Ease the usage of `build_idfboot.sh` for building the IDF bootloader outside of Docker
- Checkout the `esp-idf` submodule from this repository in case `IDF_PATH` is not set. Since the `espressif/esp-idf` Docker image already sets IDF_PATH by default, the previous behavior is still maintained.
- Use Ninja as the CMake makefile generator only if available. Otherwise, rely on the default Unix Makefiles.

### Allow providing custom SDK configuration for building the IDF bootloader
- `SDKCONFIG_DEFAULTS` file may provided via `-f <file>` option. This enables an easy method for overriding SPI Flash parameters without modifying the build script.