### PR TITLE
IDFboot: Set esp-idf submodule to track a tag instead of branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,3 @@
 [submodule "esp-idf"]
 	path = esp-idf
 	url = https://github.com/espressif/esp-idf.git
-	branch = release/v4.3


### PR DESCRIPTION
This PR intends to fix the submodule reference to the `esp-idf` repository.

It should track the `v4.3` tag and not the `release/v4.3` branch.