### PR TITLE
Fix SC2076 warning from ShellCheck

### DIFF
--- a/build_idfboot.sh
+++ b/build_idfboot.sh
@@ -130,7 +130,7 @@ if [ -n "${partinfo}" ] && [ ! -f "${partinfo}" ]; then
   exit 1
 fi
 
-if [[ ! "${supported_targets[*]}" =~ "${chip}" ]]; then
+if [[ ! "${supported_targets[*]}" =~ ${chip} ]]; then
   printf "ERROR: Target \"%s\" is not supported!\n" "${chip}"
   usage
   exit 1

--- a/build_mcuboot.sh
+++ b/build_mcuboot.sh
@@ -123,7 +123,7 @@ if [ -n "${config}" ] && [ ! -f "${config}" ]; then
   exit 1
 fi
 
-if [[ ! "${supported_targets[*]}" =~ "${chip}" ]]; then
+if [[ ! "${supported_targets[*]}" =~ ${chip} ]]; then
   printf "ERROR: Target \"%s\" is not supported!\n" "${chip}"
   usage
   exit 1


### PR DESCRIPTION
This PR intends to fix the following [warning emitted by ShellCheck](https://github.com/koalaman/shellcheck/wiki/SC2076):

> Remove quotes from right-hand side of =~ to match as a regex rather than literally.

