### PR TITLE
idfboot: Add ESP32-S3 to the list of supported targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        targets: [esp32, esp32s2, esp32c3]
+        targets: [esp32, esp32s2, esp32s3, esp32c3]
     steps:
       - uses: actions/checkout@v2
       - name: Build IDF bootloader and partition table
-        uses: docker://docker.io/espressif/idf:release-v4.3
+        uses: docker://docker.io/espressif/idf:v4.4
         with:
           args: ./build_idfboot.sh -c ${{matrix.targets}}
       - uses: actions/upload-artifact@v2

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Chip | Bootloader | Partition table
 -----|------------|-----------------
 ESP32 | [bootloader-esp32.bin](https://github.com/espressif/esp-nuttx-bootloader/releases/download/latest/bootloader-esp32.bin) | [partition-table-esp32.bin](https://github.com/espressif/esp-nuttx-bootloader/releases/download/latest/partition-table-esp32.bin)
 ESP32-S2 | [bootloader-esp32s2.bin](https://github.com/espressif/esp-nuttx-bootloader/releases/download/latest/bootloader-esp32s2.bin) | [partition-table-esp32s2.bin](https://github.com/espressif/esp-nuttx-bootloader/releases/download/latest/partition-table-esp32s2.bin)
+ESP32-S3 | [bootloader-esp32s3.bin](https://github.com/espressif/esp-nuttx-bootloader/releases/download/latest/bootloader-esp32s3.bin) | [partition-table-esp32s3.bin](https://github.com/espressif/esp-nuttx-bootloader/releases/download/latest/partition-table-esp32s3.bin)
 ESP32-C3 | [bootloader-esp32c3.bin](https://github.com/espressif/esp-nuttx-bootloader/releases/download/latest/bootloader-esp32c3.bin) | [partition-table-esp32c3.bin](https://github.com/espressif/esp-nuttx-bootloader/releases/download/latest/partition-table-esp32c3.bin)
 
 ## MCUboot bootloader

--- a/build_idfboot.sh
+++ b/build_idfboot.sh
@@ -11,7 +11,7 @@ IDF_PATH="${IDF_PATH:-${SCRIPT_ROOTDIR}/esp-idf}"
 
 set -eo pipefail
 
-supported_targets=("esp32" "esp32s2" "esp32c3")
+supported_targets=("esp32" "esp32s2" "esp32s3" "esp32c3")
 
 usage() {
   echo ""


### PR DESCRIPTION
This PR intends to enable the generation of the **IDFboot** bootloader images for the **ESP32-S3** target.