### PR TITLE
IDFboot: Allow bypassing the MPU configuration on bootloader initialization

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,12 @@ jobs:
       matrix:
         targets: [esp32, esp32s2, esp32s3, esp32c3]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build IDF bootloader and partition table
         uses: docker://docker.io/espressif/idf:v4.4.1
         with:
           args: ./build_idfboot.sh -c ${{matrix.targets}}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: idf-builds
           path: out/
@@ -29,12 +29,12 @@ jobs:
       matrix:
         targets: [esp32, esp32s2, esp32c3]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build MCUboot bootloader
         uses: docker://docker.io/espressif/idf:release-v4.4
         with:
           args: ./build_mcuboot.sh -s -c ${{matrix.targets}}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: mcuboot-builds
           path: out/
@@ -44,7 +44,7 @@ jobs:
     needs: [IDFboot, MCUboot]
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: buildartifacts/
       - name: Update release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build MCUboot bootloader
         uses: docker://docker.io/espressif/idf:release-v4.4
         with:
-          args: ./build_mcuboot.sh -s -c ${{matrix.targets}}
+          args: /bin/sh -c "git config --global --add safe.directory '*' && ./build_mcuboot.sh -s -c ${{matrix.targets}}"
       - uses: actions/upload-artifact@v3
         with:
           name: mcuboot-builds

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build IDF bootloader and partition table
-        uses: docker://docker.io/espressif/idf:v4.4
+        uses: docker://docker.io/espressif/idf:v4.4.1
         with:
           args: ./build_idfboot.sh -c ${{matrix.targets}}
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
This PR intends to bump the IDF revision to include a patch to revision v4.4 which creates a new option for bypassing the MPU configuration on bootloader initialization.

The motivation for this patch is to allow the NuttX application firmware image to perform a different configuration.