### PR TITLE
idfboot: Skip MPU configuration in IDFboot bootloader

### DIFF
--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -2,6 +2,10 @@ CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y
 CONFIG_ESPTOOLPY_FLASHMODE_DIO=y
 CONFIG_ESPTOOLPY_FLASHFREQ_40M=y
 
+# Skip MPU configuration in bootloader, required for
+# allowing its configuration in NuttX image
+CONFIG_BOOTLOADER_REGION_PROTECTION_ENABLE=n
+
 # Use the partition table from this repository
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"


### PR DESCRIPTION
Instead, MPU configuration will be performed during the startup of the
NuttX application firmware image.