### PR TITLE
ci: Change IDF Docker image to track release-v4.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build IDF bootloader and partition table
-        uses: docker://docker.io/espressif/idf:v4.4.1
+        uses: docker://docker.io/espressif/idf:release-v4.4
         with:
           args: ./build_idfboot.sh -c ${{matrix.targets}}
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
Ideally, CI should rely on release tags of the IDF Docker image, but the ESP32-C3 prebuilt bootloader image lacks the latest patches, which will become available on IDF release v4.4.2.