### PR TITLE
ci: Update GitHub Action for uploading artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
           path: buildartifacts/
       - name: Update release
         if: "github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')"
-        uses: eine/tip@master
+        uses: pyTooling/Actions/releaser@r0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |


### PR DESCRIPTION
## Summary
The GitHub Action [tip](https://github.com/eine/tip) was deprecated, this results in the printing of the following warning message on CI:

```
DEPRECATED! 'tip' was merged into pyTooling/Actions and renamed to 'releaser'.
It is recommended to use `uses: pyTooling/Actions/releaser@main`, instead of `uses: eine/tip@master`.
```