### PR TITLE
mcuboot: Add ESP32-S3 to the list of supported targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        targets: [esp32, esp32s2, esp32c3]
+        targets: [esp32, esp32s2, esp32s3, esp32c3]
     steps:
       - uses: actions/checkout@v3
       - name: Build MCUboot bootloader

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Chip | Bootloader
 -----|------------
 ESP32 | [mcuboot-esp32.bin](https://github.com/espressif/esp-nuttx-bootloader/releases/download/latest/mcuboot-esp32.bin)
 ESP32-S2 | [mcuboot-esp32s2.bin](https://github.com/espressif/esp-nuttx-bootloader/releases/download/latest/mcuboot-esp32s2.bin)
+ESP32-S3 | [mcuboot-esp32s3.bin](https://github.com/espressif/esp-nuttx-bootloader/releases/download/latest/mcuboot-esp32s3.bin)
 ESP32-C3 | [mcuboot-esp32c3.bin](https://github.com/espressif/esp-nuttx-bootloader/releases/download/latest/mcuboot-esp32c3.bin)
 
 The prebuilt bootloader image considers the following default partitioning of the chip's SPI Flash for the application slots:

--- a/build_mcuboot.sh
+++ b/build_mcuboot.sh
@@ -12,7 +12,7 @@ IDF_PATH="${IDF_PATH:-${MCUBOOT_ROOTDIR}/boot/espressif/hal/esp-idf}"
 
 set -eo pipefail
 
-supported_targets=("esp32" "esp32s2" "esp32c3")
+supported_targets=("esp32" "esp32s2" "esp32s3" "esp32c3")
 
 usage() {
   echo ""


### PR DESCRIPTION
This PR enables the build of MCUboot bootloader for ESP32-S3 target.
It also bumps the MCUboot version to v1.9.0 that already have ESP32-S3 support.